### PR TITLE
remove additional call for '*' listeners afeter emitting '*'

### DIFF
--- a/JavaScript/3-enhanced.js
+++ b/JavaScript/3-enhanced.js
@@ -6,7 +6,7 @@ const emitter = () => {
   const ee = new events.EventEmitter();
   const emit = ee.emit;
   ee.emit = (...args) => {
-    emit.apply(ee, args);
+    if (args[0] !== '*') emit.apply(ee, args);
     args.unshift('*');
     emit.apply(ee, args);
   };

--- a/JavaScript/4-star-fix.js
+++ b/JavaScript/4-star-fix.js
@@ -6,7 +6,7 @@ const emitter = () => {
   const ee = new events.EventEmitter();
   const emit = ee.emit;
   ee.emit = (...args) => {
-    emit.apply(ee, args);
+    if (args[0] !== '*') emit.apply(ee, args);
     args.unshift('*');
     emit.apply(ee, args);
   };


### PR DESCRIPTION
Before fix:
```
Certain event
{ a: 5 }
Any event
[ 'smth', { a: 5 } ]
Any event
[ 'smth2', { a: 500 } ]
Any event
[ { a: 700 }, undefined ]
Any event
[ '*', { a: 700 } ]
```
After:
```
Certain event
{ a: 5 }
Any event
[ 'smth', { a: 5 } ]
Any event
[ 'smth2', { a: 500 } ]
Any event
[ '*', { a: 700 } ]
```