### PR TITLE
Fix an error for `listeners` method

### DIFF
--- a/JavaScript/8-methods.js
+++ b/JavaScript/8-methods.js
@@ -38,7 +38,7 @@ const emitter = () => {
     },
     listeners: (name) => {
       const event = events[name];
-      return event.slice();
+      return event ? event.slice() : [];
     },
     names: () => Object.keys(events)
   };

--- a/JavaScript/a-prod.js
+++ b/JavaScript/a-prod.js
@@ -49,7 +49,7 @@ const emitter = () => {
     },
     listeners: (name) => {
       const event = events.get(name);
-      return event.slice();
+      return event ? event.slice() : [];
     },
     names: () => [...events.keys()]
   };


### PR DESCRIPTION
Fix an error for the  `listeners` method when the name doesn't exist in events