### PR TITLE
Event emitter class

### DIFF
--- a/JavaScript/b-class.js
+++ b/JavaScript/b-class.js
@@ -32,7 +32,7 @@ class EventEmitter {
     if (!event) return;
     if (event.has(fn)) {
       event.delete(fn);
-      return;
+      if (event.size === 0) this.events.delete(name);
     }
   }
 

--- a/JavaScript/b-class.js
+++ b/JavaScript/b-class.js
@@ -3,7 +3,6 @@
 class EventEmitter {
   constructor() {
     this.events = new Map();
-    this.wrappers = new Map();
   }
 
   on(name, fn) {
@@ -17,7 +16,6 @@ class EventEmitter {
       this.remove(name, wrapper);
       fn(...args);
     };
-    this.wrappers.set(fn, wrapper);
     this.on(name, wrapper);
   }
 
@@ -35,11 +33,6 @@ class EventEmitter {
     if (event.has(fn)) {
       event.delete(fn);
       return;
-    }
-    const wrapper = this.wrappers.get(fn);
-    if (wrapper) {
-      event.delete(wrapper);
-      if (event.size === 0) this.events.delete(name);
     }
   }
 


### PR DESCRIPTION
У методі once ми створюємо обгортку для переданої функції, щоб видаляти цю функції з події після першого її застосування, потім записуємо цю обгортку до хеш-таблиці wrappers та використовуємо метод on, у який передаємо назву події та обгортку, тобто після цього events буде виглядати приблизно так: `{ name: [wrapper] }`. Метод on запише в events передану функцію (у цьому випадку обгортку функції) під ключем назви події. У методі remove ми шукаємо подію та видаляємо з неї передану функцію, але якщо така функція не знайдена, то ми шукатимемо її в хеш-таблиці wrappers. Справа в тому, що в методі once ми завжди записуємо в events обгортку функції та видаляємо саме обгортку. Тоді при видаленні функції з події після виконання once ми завжди будемо знаходити потрібну обгортку та не треба буде шукати в хеш-таблиці wrappers функцію, яка лежить в обгортці.